### PR TITLE
Fix scroll to refresh for dashboard and history screen (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The SensorIoT app is a react-native app that works with the SensorIoT GW, Sensor
 
 # Installation
 Prerequisites:
-- [react-native](https://facebook.github.io/react-native/docs/getting-started) and follow the "Building Projects with Native Code" directions for your platform.
+- The first order of business is to make sure you have a functional [react-native](https://facebook.github.io/react-native/docs/getting-started) development environment. Follow the "Building Projects with Native Code" directions for your platform.
   Follow these directions until you can successfully run the test app (AwesomeProject) in the emulator.
   
   This will have you install the other following dependencies as appropriate:
@@ -14,19 +14,15 @@ Prerequisites:
   - [XCode](https://developer.apple.com/xcode/) or [Android Studio](https://developer.android.com/studio/index.html) (or both)
   - [java](https://www.java.com) java SE Development Kit (JDK) (version 8 or better)
 
+- You will also need git if you dont already have it [git](https://www.git-scm.com/downloads)
 
 Once the prereqs are installed, in your dev area on your local machine:
   - git clone https://github.com/ChrisBrinton/SensorIoT_app
-  - react-native init SensorIoT_app
   - cd SensorIoT_app
-  - (discard changes to git for this repo)
   - npm install
-  - react-native link react-native-svg
-  - react-native link react-native-splash-screen
   - react-native run-android (or react-native run-ios)
 
-See the react-native documentation for build details on different platforms and targets [here](https://facebook.github.io/react-native/docs/running-on-device)
-
+On Android, depending on how many revisions Android Studio and react-native have moved forward, you may need to fiddle with the android/app/build.gradle file to get the sdk version matched properly.
 
 ## Building the SensorIoT app
 The current build instructions are based on running the Android Studio build environment on Windows using VSCode as an IDE and the Android Simulator to test & debug.

--- a/components/DashboardScrollView.js
+++ b/components/DashboardScrollView.js
@@ -1,12 +1,25 @@
 import React from 'React';
-import { ScrollView, StyleSheet } from 'react-native';
+import { Dimensions, RefreshControl, ScrollView, StyleSheet } from 'react-native';
 
-const DashboardScrollView = ({ children, onScrollEndDrag }) => {
-  //console.log('ControlsButton created with children:', children);
+//_onRefresh = () => {
+//  console.log('refreshing');
+//}
+
+const DashboardScrollView = ({ children, onScrollEndDrag, onRefresh }) => {
+  console.log('DashboardScrollview created with Dimensions ', Dimensions);
   return (
       <ScrollView
+
         style={styles.dashboardScrollView}
-        onScrollEndDrag={onScrollEndDrag}>
+        refreshControl={ 
+          <RefreshControl
+            refreshing={false}
+            onRefresh={onRefresh}
+            />
+         }
+//        onScrollEndDrag={onScrollEndDrag}
+
+      >
         {children}
       </ScrollView>
   )

--- a/components/HistoryScreenScrollView.js
+++ b/components/HistoryScreenScrollView.js
@@ -1,5 +1,5 @@
 import React from 'React';
-import { ScrollView, StyleSheet } from 'react-native';
+import { RefreshControl, ScrollView, StyleSheet } from 'react-native';
 import { connect } from 'react-redux'
 import { fetchSensorData } from '../actions';
 
@@ -17,14 +17,14 @@ isScrollAtAnEnd = ({ layoutMeasurement, contentOffset, contentSize }) => {
 
 
 const mapStateToProps = (state, ownProps) => {
-    //console.log('DisplayDashboardScrollView mapStateToProps ownProps:', ownProps);
+    //console.log('HistoryScreenScrollView mapStateToProps ownProps:', ownProps);
     return ({
         isLoading: state.histogramDataSet.isLoading,
     })
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-    //console.log('DisplayDashboardScrollView mapDispatchToProps ownProps:', ownProps);
+    console.log('HistoryScreenScrollView mapDispatchToProps ownProps:', ownProps);
     return {
         onScrollEndDrag: ({ nativeEvent }) => {
             if (isScrollAtAnEnd(nativeEvent)) {
@@ -32,18 +32,29 @@ const mapDispatchToProps = (dispatch, ownProps) => {
             } else {
                 return;
             }
+        },
+        onRefresh: () => {
+            //console.log('onRefresh');
+            return(dispatch(fetchSensorData()));
         }
     }
 }
 
 
 
-const HistoryScreenScrollView = ({ children, onScrollEndDrag }) => {
+const HistoryScreenScrollView = ({ children, onScrollEndDrag, onRefresh }) => {
     //console.log('ControlsButton created with children:', children);
     return (
         <ScrollView
             style={styles.HistoryScreenScrollView}
-            onScrollEndDrag={onScrollEndDrag}>
+            refreshControl={ 
+                <RefreshControl
+                  refreshing={false}
+                  onRefresh={onRefresh}
+                  />
+            }
+//            onScrollEndDrag={onScrollEndDrag}
+        >
             {children}
         </ScrollView>
     )

--- a/components/SettingsScrollView.js
+++ b/components/SettingsScrollView.js
@@ -2,7 +2,7 @@ import React from 'React';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import PropTypes from 'prop-types';
 
-const DashboardScrollView = ({ children, onScrollEndDrag }) => {
+const SettingsScrollView = ({ children, onScrollEndDrag }) => {
   //console.log('ControlsButton created with children:', children);
   return (
       <ScrollView
@@ -13,7 +13,7 @@ const DashboardScrollView = ({ children, onScrollEndDrag }) => {
   )
 }
 
-export default DashboardScrollView
+export default SettingsScrollView
 
 const styles = StyleSheet.create({
   scrollView: {

--- a/containers/DisplayDashboardScrollView.js
+++ b/containers/DisplayDashboardScrollView.js
@@ -30,6 +30,10 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       } else {
         return;
       }
+    },
+    onRefresh: () => {
+      console.log('onRefresh');
+      return(dispatch(fetchNodeLatestData()));
     }
   }
 }


### PR DESCRIPTION
Eliminated onScrollEndDrag as the mechanism for pull to refresh and started using the RefreshControl prop of ScrollView which should work consistently across OSs.

May need/want to move to a custom class like react-native-pull-refresh